### PR TITLE
Actualizar status de un sobre

### DIFF
--- a/lib/docusign_ex/api/base.ex
+++ b/lib/docusign_ex/api/base.ex
@@ -4,12 +4,23 @@ defmodule DocusignEx.Api.Base do
   """
 
   @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
+  @connect_timeout 100000
+  @recv_timeout 100000
+  @timeout 100000
 
   use HTTPoison.Base
 
   def api, do: Process.get("base_url")
   defp process_url(url), do: api() <> url
   defp process_request_body(body), do: Poison.encode!(body)
+
+  defp process_request_options(options) do
+    [
+      connect_timeout: @connect_timeout,
+      recv_timeout: @recv_timeout,
+      timeout: @timeout
+    ]
+  end
 
   defp process_request_headers(headers) do
     username = Application.get_env(:docusign_ex, :username)
@@ -20,7 +31,7 @@ defmodule DocusignEx.Api.Base do
     [
       {"X-DocuSign-Authentication", auth_headers},
       {"Content-Type", "application/json"},
-    ]
+    ] ++ headers
   end
 
   defp process_response_body(body) do

--- a/lib/docusign_ex/api/base.ex
+++ b/lib/docusign_ex/api/base.ex
@@ -4,24 +4,36 @@ defmodule DocusignEx.Api.Base do
   """
 
   @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
-  @connect_timeout 100000
-  @recv_timeout 100000
-  @timeout 100000
+  @connect_timeout 100_000
+  @recv_timeout 100_000
+  @timeout 100_000
 
   use HTTPoison.Base
 
+  # Devuelve el endpoint de Docusign
+  @spec api :: String.t
   def api, do: Process.get("base_url")
+
+  # Devuelve el path a donde se hace la petición
+  @spec process_url(String.t) :: String.t
   defp process_url(url), do: api() <> url
+
+  # Encodear de mapa a string el body
+  @spec process_request_body(map) :: String.t
   defp process_request_body(body), do: Poison.encode!(body)
 
+  # Agrega los opciones compartidos por todos los requests que usen este módulo
+  @spec process_request_options(list) :: list
   defp process_request_options(options) do
     [
       connect_timeout: @connect_timeout,
       recv_timeout: @recv_timeout,
       timeout: @timeout
-    ]
+    ] ++ options
   end
 
+  # Agrega los headers compartidos por todos los requests que usen este módulo
+  @spec process_request_headers(list) :: list
   defp process_request_headers(headers) do
     username = Application.get_env(:docusign_ex, :username)
     password = Application.get_env(:docusign_ex, :password)
@@ -34,6 +46,8 @@ defmodule DocusignEx.Api.Base do
     ] ++ headers
   end
 
+  # Devuelve la respuesta de Docusign en un mapa o un atomo de error si fallo
+  @spec process_response_body(String.t) :: :error | map
   defp process_response_body(body) do
     case Poison.decode(body) do
       {:ok, success_response} ->
@@ -42,5 +56,4 @@ defmodule DocusignEx.Api.Base do
         :error
     end
   end
-
 end

--- a/lib/docusign_ex/api/envelope.ex
+++ b/lib/docusign_ex/api/envelope.ex
@@ -10,10 +10,6 @@ defmodule DocusignEx.Api.Envelope do
   alias HTTPoison.Error
   alias DocusignEx.Mapper.EnvelopeMapper
 
-  @connect_timeout 100000
-  @recv_timeout 100000
-  @timeout 100000
-
   @doc """
   Envia un documento para que el remitente pueda firmarlo.
 
@@ -22,7 +18,7 @@ defmodule DocusignEx.Api.Envelope do
         "subject" => "Test",
         "signers" => [...]
       }
-      iex> DocusignEx.Api.Envelope(data)
+      iex> DocusignEx.Api.Envelope.send_envelope(data)
       %{
         "envelopeId" => "5aadc814-53be-4a03-8590-6cf381faa163",
         "status" => "sent",
@@ -35,15 +31,7 @@ defmodule DocusignEx.Api.Envelope do
     envelope = EnvelopeMapper.map(envelope_data)
 
     "/envelopes"
-    |> Base.post(
-         envelope,
-         [],
-         [
-           connect_timeout: @connect_timeout,
-           recv_timeout: @recv_timeout,
-           timeout: @timeout
-         ]
-       )
+    |> Base.post(envelope)
     |> _parse_post_response()
   end
 
@@ -53,14 +41,7 @@ defmodule DocusignEx.Api.Envelope do
   @spec get_envelope(String.t()) :: map
   def get_envelope(envelope_uid) do
     "/envelopes/#{envelope_uid}"
-    |> Base.get(
-         [],
-         [
-           connect_timeout: @connect_timeout,
-           recv_timeout: @recv_timeout,
-           timeout: @timeout
-         ]
-       )
+    |> Base.get()
     |> _parse_get_response()
   end
 
@@ -70,14 +51,7 @@ defmodule DocusignEx.Api.Envelope do
   @spec get_documents(String.t()) :: map
   def get_documents(envelope_uid) do
     "/envelopes/#{envelope_uid}/documents"
-    |> Base.get(
-         [],
-         [
-           connect_timeout: @connect_timeout,
-           recv_timeout: @recv_timeout,
-           timeout: @timeout
-         ]
-       )
+    |> Base.get()
     |> _parse_get_response()
   end
 
@@ -87,14 +61,7 @@ defmodule DocusignEx.Api.Envelope do
   @spec download_document(String.t, String.t) :: map
   def download_document(envelope_uid, document_id) do
     "/envelopes/#{envelope_uid}/documents/#{document_id}"
-    |> DownloadFile.get(
-         [],
-         [
-           connect_timeout: @connect_timeout,
-           recv_timeout: @recv_timeout,
-           timeout: @timeout
-         ]
-       )
+    |> DownloadFile.get()
     |> _parse_download_response()
   end
 

--- a/lib/docusign_ex/api/envelope.ex
+++ b/lib/docusign_ex/api/envelope.ex
@@ -40,16 +40,17 @@ defmodule DocusignEx.Api.Envelope do
 
   ## Ejemplos
     iex> data = %{"status" => "voided" =>, "voidedReason" => "The reason"}
-    iex> DocusignEx.Api.Envelope.send_envelope(data)
-    %{
-      "message" => "SUCCESSS"
+    iex> envelope_uid = "2a4674c5-4fd4-47b0-9af0-89970dd8e6c9"
+    iex> DocusignEx.Api.Envelope.send_envelope(envelope_uid, data)
+    {
+      :ok, %{"envelopeId" => "2a4674c5-4fd4-47b0-9af0-89970dd8e6c9"}
     }
   """
   @spec update_envelope(String.t, map) :: map
   def update_envelope(envelope_uid, data) do
     "/envelopes/#{envelope_uid}"
     |> Base.put(data)
-    |> _parse_get_response()
+    |> _parse_response()
   end
 
   @doc """
@@ -59,7 +60,7 @@ defmodule DocusignEx.Api.Envelope do
   def get_envelope(envelope_uid) do
     "/envelopes/#{envelope_uid}"
     |> Base.get()
-    |> _parse_get_response()
+    |> _parse_response()
   end
 
   @doc """
@@ -69,7 +70,7 @@ defmodule DocusignEx.Api.Envelope do
   def get_documents(envelope_uid) do
     "/envelopes/#{envelope_uid}/documents"
     |> Base.get()
-    |> _parse_get_response()
+    |> _parse_response()
   end
 
   @doc """
@@ -101,11 +102,11 @@ defmodule DocusignEx.Api.Envelope do
     "message" => "Unknown error"
   }}
 
-  @spec _parse_get_response(tuple) :: tuple
-  defp _parse_get_response({:ok, %Response{body: body, status_code: 200}}) do
+  @spec _parse_response(tuple) :: tuple
+  defp _parse_response({:ok, %Response{body: body, status_code: 200}}) do
     {:ok, body}
   end
-  defp _parse_get_response(error) do
+  defp _parse_response(error) do
     Logger.error(
       "No se pudo obtener información del paquete, #{inspect(error)}"
     )

--- a/lib/docusign_ex/api/envelope.ex
+++ b/lib/docusign_ex/api/envelope.ex
@@ -36,6 +36,23 @@ defmodule DocusignEx.Api.Envelope do
   end
 
   @doc """
+  Actualiza un sobre por medio del uid
+
+  ## Ejemplos
+    iex> data = %{"status" => "voided" =>, "voidedReason" => "The reason"}
+    iex> DocusignEx.Api.Envelope.send_envelope(data)
+    %{
+      "message" => "SUCCESSS"
+    }
+  """
+  @spec update_envelope(String.t, map) :: map
+  def update_envelope(envelope_uid, data) do
+    "/envelopes/#{envelope_uid}"
+    |> Base.put(data)
+    |> _parse_get_response()
+  end
+
+  @doc """
   Obtiene la información de un sobre de docusign
   """
   @spec get_envelope(String.t()) :: map

--- a/test/api/envelope_test.exs
+++ b/test/api/envelope_test.exs
@@ -64,7 +64,7 @@ defmodule DocusignEx.Api.EnvelopeTest do
         DocusignEx.Api.Base,
         [],
         [
-          post: fn(_, _, _, _) ->
+          post: fn(_, _) ->
             {:ok, %HTTPoison.Response{
               body: %{"envelopeId" => "123"}, headers: [], status_code: 201}}
           end
@@ -82,7 +82,7 @@ defmodule DocusignEx.Api.EnvelopeTest do
         DocusignEx.Api.Base,
         [],
         [
-          post: fn(_, _, _, _) ->
+          post: fn(_, _) ->
             {:ok, %HTTPoison.Response{
               body: %{
                 "errorCode" => "INVALID_EMAIL_ADDRESS_FOR_RECIPIENT",
@@ -96,6 +96,29 @@ defmodule DocusignEx.Api.EnvelopeTest do
         {:error, %{
           "errorCode" => "INVALID_EMAIL_ADDRESS_FOR_RECIPIENT",
           "message" => "The email address for the recipient is invalid. The recipient Id follows."}}
+    end
+  end
+
+  test "update_envelope/2 updates the envelope status" do
+    with_mocks([
+      {
+        DocusignEx.Api.Base,
+        [],
+        [
+          put: fn(_, _) ->
+            {:ok, %HTTPoison.Response{
+              body: %{
+                "errorCode" => "",
+                "message" => "SUCCESS"
+              }, headers: [], status_code: 200}}
+          end
+        ]
+      }
+    ]) do
+      assert Envelope.update_envelope("SOME-UID", %{
+        "status" => "voided",
+        "voidedReason" => "The reason for voiding the envelope"
+      }) == {:ok, %{"errorCode" => "", "message" => "SUCCESS"}}
     end
   end
 end


### PR DESCRIPTION
- Se agrega método para poder actualizar un sobre
`https://docs.docusign.com/esign/restapi/Envelopes/Envelopes/update/`

- Se añaden todos los headers al modulo Base