### PR TITLE
Deshace configuración personalizada

### DIFF
--- a/lib/docusign_ex/api/base.ex
+++ b/lib/docusign_ex/api/base.ex
@@ -26,9 +26,9 @@ defmodule DocusignEx.Api.Base do
   @spec process_request_options(list) :: list
   defp process_request_options(options) do
     [
-      connect_timeout: Application.get_env(:docusign_ex, :connect_timeout, @connect_timeout),
-      recv_timeout: Application.get_env(:docusign_ex, :recv_timeout, @recv_timeout),
-      timeout: Application.get_env(:docusign_ex, :timeout, @timeout)
+      connect_timeout: @connect_timeout,
+      recv_timeout: @recv_timeout,
+      timeout: @timeout
     ] ++ options
   end
 


### PR DESCRIPTION
Esto generaba errores al usarse desde una aplicacion cliente por lo
que se deshace para generar una versión fix

Esta funcionalidad se agregará en una nueva versión