### PR TITLE
Adds logic for acces with credito credentials

### DIFF
--- a/lib/docusign_ex/api/auth.ex
+++ b/lib/docusign_ex/api/auth.ex
@@ -7,6 +7,7 @@ defmodule DocusignEx.Api.Auth do
 
   alias DocusignEx.Api.AuthBase
   alias DocusignEx.Api.LaTasaAuthBase
+  alias DocusignEx.Api.CreditoAuthBase
   alias HTTPoison.Response
   alias HTTPoison.Error
 

--- a/lib/docusign_ex/api/auth.ex
+++ b/lib/docusign_ex/api/auth.ex
@@ -28,6 +28,20 @@ defmodule DocusignEx.Api.Auth do
     end
   end
 
+  def login(:credito) do
+    response = CreditoAuthBase.get("/login_information?api_password=true")
+
+    case response do
+      {:ok, %Response{body: body}} ->
+        base_url = get_base_url(body)
+        Process.put("base_url", base_url)
+        base_url
+
+      {:error, %Error{reason: reason}} ->
+        Logger.error(reason)
+    end
+  end
+
   def login() do
     response = AuthBase.get("/login_information?api_password=true")
 

--- a/lib/docusign_ex/api/credito_auth_base.ex
+++ b/lib/docusign_ex/api/credito_auth_base.ex
@@ -1,0 +1,30 @@
+defmodule DocusignEx.Api.CreditoAuthBase do
+  @moduledoc """
+  Funcionalidades básicas y comunes del API del Docusign
+  """
+
+  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
+
+  use HTTPoison.Base
+
+  def api, do: Application.get_env(:docusign_ex, :host)
+  defp process_url(url), do: api() <> url
+  defp process_request_body(body), do: Poison.encode!(body)
+
+  defp process_request_headers(_headers) do
+    username = Application.get_env(:docusign_ex, :credito_username)
+    password = Application.get_env(:docusign_ex, :credito_password)
+    integrator_key = Application.get_env(:docusign_ex, :integrator_key)
+    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
+
+    [
+      {"X-DocuSign-Authentication", auth_headers},
+      {"Content-Type", "application/json"}
+    ]
+  end
+
+  defp process_response_body(body) do
+    {:ok, success_response} = Poison.decode(body)
+    success_response
+  end
+end

--- a/lib/docusign_ex/api/credito_base.ex
+++ b/lib/docusign_ex/api/credito_base.ex
@@ -1,0 +1,60 @@
+defmodule DocusignEx.Api.CreditoBase do
+  @moduledoc """
+  Funcionalidades básicas y comunes del API del Docusign
+  """
+
+  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
+  @connect_timeout 100_000
+  @recv_timeout 100_000
+  @timeout 100_000
+
+  use HTTPoison.Base
+
+  # Devuelve el endpoint de Docusign
+  @spec api :: String.t()
+  def api, do: Process.get("base_url")
+
+  # Devuelve el path a donde se hace la petición
+  @spec process_url(String.t()) :: String.t()
+  defp process_url(url), do: api() <> url
+
+  # Encodear de mapa a string el body
+  @spec process_request_body(map) :: String.t()
+  defp process_request_body(body), do: Poison.encode!(body)
+
+  # Agrega los opciones compartidos por todos los requests que usen este módulo
+  @spec process_request_options(list) :: list
+  defp process_request_options(options) do
+    [
+      connect_timeout: @connect_timeout,
+      recv_timeout: @recv_timeout,
+      timeout: @timeout
+    ] ++ options
+  end
+
+  # Agrega los headers compartidos por todos los requests que usen este módulo
+  @spec process_request_headers(list) :: list
+  defp process_request_headers(headers) do
+    username = Application.get_env(:docusign_ex, :credito_username)
+    password = Application.get_env(:docusign_ex, :credito_password)
+    integrator_key = Application.get_env(:docusign_ex, :integrator_key)
+    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
+
+    [
+      {"X-DocuSign-Authentication", auth_headers},
+      {"Content-Type", "application/json"}
+    ] ++ headers
+  end
+
+  # Devuelve la respuesta de Docusign en un mapa o un atomo de error si fallo
+  @spec process_response_body(String.t()) :: :error | map
+  defp process_response_body(body) do
+    case Poison.decode(body) do
+      {:ok, success_response} ->
+        success_response
+
+      _ ->
+        :error
+    end
+  end
+end


### PR DESCRIPTION
With this canges, Kor can use the credit credentials for the correct docusign account and send the corresponding template.