### PR TITLE
Replace sprintf dependency usage with Poison.encode!

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ by adding `docusign_ex` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:docusign_ex, "~> 0.1.0"}]
+  [{:docusign_ex, "~> 1.5.0"}]
 end
 ```
 

--- a/lib/docusign_ex/api/auth_base.ex
+++ b/lib/docusign_ex/api/auth_base.ex
@@ -3,9 +3,9 @@ defmodule DocusignEx.Api.AuthBase do
   Funcionalidades básicas y comunes del API del Docusign
   """
 
-  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
-
   use HTTPoison.Base
+
+  alias DocusignEx.Api.Helper
 
   def api, do: Application.get_env(:docusign_ex, :host)
   defp process_url(url), do: api() <> url
@@ -15,10 +15,9 @@ defmodule DocusignEx.Api.AuthBase do
     username = Application.get_env(:docusign_ex, :username)
     password = Application.get_env(:docusign_ex, :password)
     integrator_key = Application.get_env(:docusign_ex, :integrator_key)
-    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
 
     [
-      {"X-DocuSign-Authentication", auth_headers},
+      Helper.build_custom_auth_header(username, password, integrator_key),
       {"Content-Type", "application/json"}
     ]
   end

--- a/lib/docusign_ex/api/base.ex
+++ b/lib/docusign_ex/api/base.ex
@@ -3,12 +3,13 @@ defmodule DocusignEx.Api.Base do
   Funcionalidades básicas y comunes del API del Docusign
   """
 
-  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
   @connect_timeout 100_000
   @recv_timeout 100_000
   @timeout 100_000
 
   use HTTPoison.Base
+
+  alias DocusignEx.Api.Helper
 
   # Devuelve el endpoint de Docusign
   @spec api :: String.t()
@@ -38,10 +39,9 @@ defmodule DocusignEx.Api.Base do
     username = Application.get_env(:docusign_ex, :username)
     password = Application.get_env(:docusign_ex, :password)
     integrator_key = Application.get_env(:docusign_ex, :integrator_key)
-    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
 
     [
-      {"X-DocuSign-Authentication", auth_headers},
+      Helper.build_custom_auth_header(username, password, integrator_key),
       {"Content-Type", "application/json"}
     ] ++ headers
   end

--- a/lib/docusign_ex/api/credito_auth_base.ex
+++ b/lib/docusign_ex/api/credito_auth_base.ex
@@ -3,9 +3,9 @@ defmodule DocusignEx.Api.CreditoAuthBase do
   Funcionalidades básicas y comunes del API del Docusign
   """
 
-  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
-
   use HTTPoison.Base
+
+  alias DocusignEx.Api.Helper
 
   def api, do: Application.get_env(:docusign_ex, :host)
   defp process_url(url), do: api() <> url
@@ -15,10 +15,9 @@ defmodule DocusignEx.Api.CreditoAuthBase do
     username = Application.get_env(:docusign_ex, :credito_username)
     password = Application.get_env(:docusign_ex, :credito_password)
     integrator_key = Application.get_env(:docusign_ex, :integrator_key)
-    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
 
     [
-      {"X-DocuSign-Authentication", auth_headers},
+      Helper.build_custom_auth_header(username, password, integrator_key),
       {"Content-Type", "application/json"}
     ]
   end

--- a/lib/docusign_ex/api/credito_base.ex
+++ b/lib/docusign_ex/api/credito_base.ex
@@ -3,12 +3,13 @@ defmodule DocusignEx.Api.CreditoBase do
   Funcionalidades básicas y comunes del API del Docusign
   """
 
-  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
   @connect_timeout 100_000
   @recv_timeout 100_000
   @timeout 100_000
 
   use HTTPoison.Base
+
+  alias DocusignEx.Api.Helper
 
   # Devuelve el endpoint de Docusign
   @spec api :: String.t()
@@ -38,10 +39,9 @@ defmodule DocusignEx.Api.CreditoBase do
     username = Application.get_env(:docusign_ex, :credito_username)
     password = Application.get_env(:docusign_ex, :credito_password)
     integrator_key = Application.get_env(:docusign_ex, :integrator_key)
-    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
 
     [
-      {"X-DocuSign-Authentication", auth_headers},
+      Helper.build_custom_auth_header(username, password, integrator_key),
       {"Content-Type", "application/json"}
     ] ++ headers
   end

--- a/lib/docusign_ex/api/download_file.ex
+++ b/lib/docusign_ex/api/download_file.ex
@@ -3,9 +3,8 @@ defmodule DocusignEx.Api.DownloadFile do
   Funcionalidades para descarga de documentos
   """
 
-  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
-
   use HTTPoison.Base
+  alias DocusignEx.Api.Helper
 
   @doc """
   Devuelve la URL base para realizar peticiones a Docusign (incluyendo el id
@@ -24,10 +23,9 @@ defmodule DocusignEx.Api.DownloadFile do
     username = Application.get_env(:docusign_ex, :username)
     password = Application.get_env(:docusign_ex, :password)
     integrator_key = Application.get_env(:docusign_ex, :integrator_key)
-    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
 
     [
-      {"X-DocuSign-Authentication", auth_headers},
+      Helper.build_custom_auth_header(username, password, integrator_key),
       {"Content-Type", "application/json"}
     ]
   end

--- a/lib/docusign_ex/api/helper.ex
+++ b/lib/docusign_ex/api/helper.ex
@@ -1,0 +1,19 @@
+defmodule DocusignEx.Api.Helper do
+  @moduledoc """
+  Docusign API helpers
+  """
+
+  @doc """
+  Create a docusign custom header `X-DocuSign-Authentication` using the given parameters.
+  """
+  @spec build_custom_auth_header(String.t(), String.t(), String.t()) :: {String.t(), String.t()}
+  def build_custom_auth_header(username, password, integrator_key) do
+    payload = %{
+      "Username" => username,
+      "Password" => password,
+      "IntegratorKey" => integrator_key
+    }
+
+    {"X-DocuSign-Authentication", Poison.encode!(payload)}
+  end
+end

--- a/lib/docusign_ex/api/la_tasa_auth_base.ex
+++ b/lib/docusign_ex/api/la_tasa_auth_base.ex
@@ -3,9 +3,9 @@ defmodule DocusignEx.Api.LaTasaAuthBase do
   Funcionalidades básicas y comunes del API del Docusign
   """
 
-  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
-
   use HTTPoison.Base
+
+  alias DocusignEx.Api.Helper
 
   def api, do: Application.get_env(:docusign_ex, :host)
   defp process_url(url), do: api() <> url
@@ -15,10 +15,9 @@ defmodule DocusignEx.Api.LaTasaAuthBase do
     username = Application.get_env(:docusign_ex, :la_tasa_username)
     password = Application.get_env(:docusign_ex, :la_tasa_password)
     integrator_key = Application.get_env(:docusign_ex, :integrator_key)
-    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
 
     [
-      {"X-DocuSign-Authentication", auth_headers},
+      Helper.build_custom_auth_header(username, password, integrator_key),
       {"Content-Type", "application/json"}
     ]
   end

--- a/lib/docusign_ex/api/la_tasa_base.ex
+++ b/lib/docusign_ex/api/la_tasa_base.ex
@@ -3,12 +3,13 @@ defmodule DocusignEx.Api.LaTasaBase do
   Funcionalidades básicas y comunes del API del Docusign
   """
 
-  @auth_header "{\"Username\":\"%s\",\"Password\":\"%s\",\"IntegratorKey\": \"%s\"}"
   @connect_timeout 100_000
   @recv_timeout 100_000
   @timeout 100_000
 
   use HTTPoison.Base
+
+  alias DocusignEx.Api.Helper
 
   # Devuelve el endpoint de Docusign
   @spec api :: String.t()
@@ -38,10 +39,9 @@ defmodule DocusignEx.Api.LaTasaBase do
     username = Application.get_env(:docusign_ex, :la_tasa_username)
     password = Application.get_env(:docusign_ex, :la_tasa_password)
     integrator_key = Application.get_env(:docusign_ex, :integrator_key)
-    auth_headers = ExPrintf.sprintf(@auth_header, [username, password, integrator_key])
 
     [
-      {"X-DocuSign-Authentication", auth_headers},
+      Helper.build_custom_auth_header(username, password, integrator_key),
       {"Content-Type", "application/json"}
     ] ++ headers
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DocusignEx.Mixfile do
   def project do
     [
       app: :docusign_ex,
-      version: "0.1.0",
+      version: "1.5.0",
       elixir: "~> 1.5",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -21,7 +21,6 @@ defmodule DocusignEx.Mixfile do
     [
       {:httpoison, "~> 0.11.1"},
       {:poison, "~> 2.1 or ~> 3.1"},
-      {:exprintf, github: "parroty/exprintf"},
       {:excoveralls, "~> 0.6.3", only: :test},
       {:credo, "~> 0.8.6", only: :test},
       {:mock, "~> 0.3.1", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,6 @@
   "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.6.5", "2d3faf8fe40e77c980620f1344f6d3df2c43b18ab9c21a2c1781a898cc710184", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
-  "exprintf": {:git, "https://github.com/parroty/exprintf.git", "608ee65eca200638b2d3548beb134b7dad0e75f6", []},
   "hackney": {:hex, :hackney, "1.8.6", "21a725db3569b3fb11a6af17d5c5f654052ce9624219f1317e8639183de4a423", [:rebar3], [{:certifi, "1.2.1", [hex: :certifi, optional: false]}, {:idna, "5.0.2", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.11.2", "9e59f17a473ef6948f63c51db07320477bad8ba88cf1df60a3eee01150306665", [:mix], [{:hackney, "~> 1.8.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "5.0.2", "ac203208ada855d95dc591a764b6e87259cb0e2a364218f215ad662daa8cd6b4", [:rebar3], [{:unicode_util_compat, "0.2.0", [hex: :unicode_util_compat, optional: false]}]},

--- a/test/api/helper_test.exs
+++ b/test/api/helper_test.exs
@@ -1,0 +1,20 @@
+defmodule DocusignEx.Api.HelperTest do
+  use ExUnit.Case
+
+  alias DocusignEx.Api.Helper
+
+  test "build_custom_auth_header/3 render a correct header value" do
+    template = "{\"Username\":\"~s\",\"Password\":\"~s\",\"IntegratorKey\":\"~s\"}"
+    username = "some-username"
+    password = "some-password"
+    integrator_key = "some-key"
+
+    expected_value =
+      template
+      |> :io_lib.format([username, password, integrator_key])
+      |> List.to_string()
+
+    assert {"X-DocuSign-Authentication", expected_value} ==
+             Helper.build_custom_auth_header(username, password, integrator_key)
+  end
+end


### PR DESCRIPTION
sprintf was being used to generate a json encoded value which can be
made using poison that is already a dependency of this project

Also make a minor refactor by adding a helper module to have just one
place where generate docusign custom header