### PR TITLE
Agregar soporte para definir el idioma por destinatario firmante

### DIFF
--- a/lib/docusign_ex/mapper/envelope_mapper.ex
+++ b/lib/docusign_ex/mapper/envelope_mapper.ex
@@ -5,6 +5,8 @@ defmodule DocusignEx.Mapper.EnvelopeMapper do
 
   alias DocusignEx.Utils.FileUtils
 
+  @signer_default_lang "es"
+
   @doc """
   Mapea la información del envelope al formato que pide Docusign
   """
@@ -109,7 +111,10 @@ defmodule DocusignEx.Mapper.EnvelopeMapper do
             "name" => Map.get(signer, "name"),
             "recipientId" => acc,
             "routingOrder" => acc,
-            "tabs" => tabs
+            "tabs" => tabs,
+            "emailNotification" => %{
+              "supportedLanguage" => Map.get(signer, "lang", @signer_default_lang)
+            }
           },
           acc + 1
         }

--- a/test/mapper/envelope_mapper_test.exs
+++ b/test/mapper/envelope_mapper_test.exs
@@ -22,6 +22,9 @@ defmodule DocusignEx.Mapper.EnvelopeMapperTest do
               "name" => "Name",
               "recipientId" => 1,
               "routingOrder" => 1,
+              "emailNotification" => %{
+                "supportedLanguage" => "es"
+              },
               "tabs" => %{
                 "initialHereTabs" => [
                   %{


### PR DESCRIPTION
Por defecto se usa el español en caso no se especifique el campo
`lang` en la información del destinatario firmante