### PR TITLE
Fix wrong reference to signer name

### DIFF
--- a/lib/docusign_ex/mapper/envelope_mapper.ex
+++ b/lib/docusign_ex/mapper/envelope_mapper.ex
@@ -66,7 +66,7 @@ defmodule DocusignEx.Mapper.EnvelopeMapper do
       "emailNotification" => %{
         "supportedLanguage" => Map.get(signer, :lang, @signer_default_lang)
       },
-      "name" => signer.email,
+      "name" => signer.name,
       "recipientId" => order,
       "routingOrder" => order,
       "tabs" =>


### PR DESCRIPTION
In a previous change the signer email was put instead of signer name