### PR TITLE
Adds emailSubject to envelope

### DIFF
--- a/lib/docusign_ex/mapper/envelope_mapper.ex
+++ b/lib/docusign_ex/mapper/envelope_mapper.ex
@@ -119,6 +119,7 @@ defmodule DocusignEx.Mapper.EnvelopeMapper do
             "routingOrder" => acc,
             "tabs" => tabs,
             "emailNotification" => %{
+              "emailSubject" => Map.get(envelope, "emailSubject"),
               "supportedLanguage" => Map.get(signer, "lang", @signer_default_lang)
             }
           },

--- a/test/mapper/envelope_mapper_test.exs
+++ b/test/mapper/envelope_mapper_test.exs
@@ -23,6 +23,7 @@ defmodule DocusignEx.Mapper.EnvelopeMapperTest do
               "recipientId" => 1,
               "routingOrder" => 1,
               "emailNotification" => %{
+                "emailSubject" => "Test",
                 "supportedLanguage" => "es"
               },
               "tabs" => %{


### PR DESCRIPTION
The `emailSubject` is needed if we use the `emailNotification` field